### PR TITLE
convert datetime to string object when timestamp is missing

### DIFF
--- a/payload-receiver-service/app/main.py
+++ b/payload-receiver-service/app/main.py
@@ -32,7 +32,6 @@ async def push_to_nats(nats: NATS, payload):
     try:
         df = pd.json_normalize(payload)
         if "time" in df.columns:
-            df["temp"] = pd.to_datetime("now", utc=True)
             logging.info(str(df['temp'].tolist()))
             df.time.replace(r"^\s*$", np.nan, regex=True, inplace=True)
             df.loc[~df.time.notnull(), "time"] = pd.to_datetime("now", utc=True)

--- a/payload-receiver-service/app/main.py
+++ b/payload-receiver-service/app/main.py
@@ -32,7 +32,6 @@ async def push_to_nats(nats: NATS, payload):
     try:
         df = pd.json_normalize(payload)
         if "time" in df.columns:
-            logging.info(str(df['temp'].tolist()))
             df.time.replace(r"^\s*$", np.nan, regex=True, inplace=True)
             df.loc[~df.time.notnull(), "time"] = pd.to_datetime("now", utc=True)
         else:

--- a/payload-receiver-service/app/main.py
+++ b/payload-receiver-service/app/main.py
@@ -32,10 +32,12 @@ async def push_to_nats(nats: NATS, payload):
     try:
         df = pd.json_normalize(payload)
         if "time" in df.columns:
+            df["temp"] = pd.to_datetime("now", utc=True)
+            logging.info(str(df['temp'].tolist()))
             df.time.replace(r"^\s*$", np.nan, regex=True, inplace=True)
             df.loc[~df.time.notnull(), "time"] = pd.to_datetime("now", utc=True)
         else:
-            df["time"] = pd.to_datetime("now", utc=True)
+            df["time"] = pd.to_datetime("now", utc=True).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
             logging.info("Setting current UTC time to payload without timestamps")
         df["dt"] = pd.to_datetime(df.time, errors="coerce", utc=True)
         df["time_nanoseconds"] = df["dt"].astype(np.int64)


### PR DESCRIPTION
This will allow preprocessing service to continue working as currently written.

Before this fix, what we want the 'time' field to look like at all times:
```
'2021-05-27T20:09:01.027062116Z'
```

When logs without a `time` field come in, we set the current time as the logs' `time`
This was being set to
```
Timestamp('2021-05-28 21:47:35.221568+0000', tz='UTC')
```

Adding strftime makes it look like `'2021-05-28T21:47: 35.221568Z'`